### PR TITLE
Fix addons icon

### DIFF
--- a/scmerlin.sh
+++ b/scmerlin.sh
@@ -482,7 +482,7 @@ Mount_WebUI(){
 		fi
 		
 		if ! grep -q '.menu_Addons' /tmp/index_style.css ; then
-			echo ".menu_Addons { background: url(ext/shared-jy/addons.png); }" >> /tmp/index_style.css
+			echo ".menu_Addons { background: url(ext/shared-jy/addons.png); background-size: contain; }" >> /tmp/index_style.css
 		fi
 		
 		if ! grep -q '.dropdown-content' /tmp/index_style.css ; then


### PR DESCRIPTION
The addons icon was bothering me.

Before:
![image](https://user-images.githubusercontent.com/41600688/231853068-6ecb7b41-1d72-4f89-aca9-f762c1379d7c.png)

After:
![image](https://user-images.githubusercontent.com/41600688/231853111-9082385b-b22a-4418-a8f4-f34a8db7f04d.png)
