### PR TITLE
Bug fix when adding "startup" calls to "services-start" script.

### DIFF
--- a/scmerlin.sh
+++ b/scmerlin.sh
@@ -11,7 +11,7 @@
 ##       https://github.com/jackyaz/scMerlin        ##
 ##                                                  ##
 ######################################################
-# Last Modified: 2023-Jun-09
+# Last Modified: 2024-Mar-12
 #-----------------------------------------------------
 
 ##########       Shellcheck directives     ###########
@@ -500,6 +500,9 @@ Auto_ServiceEvent(){
 	esac
 }
 
+##----------------------------------------##
+## Modified by Martinski W. [2024-Mar-12] ##
+##----------------------------------------##
 Auto_Startup(){
 	case $1 in
 		create)
@@ -519,12 +522,12 @@ Auto_Startup(){
 				fi
 				
 				if [ "$STARTUPLINECOUNTEX" -eq 0 ]; then
-					echo "/jffs/scripts/$SCRIPT_NAME_LOWER startup"' & # '"$SCRIPT_NAME$" >> /jffs/scripts/services-start
+					echo "/jffs/scripts/$SCRIPT_NAME_LOWER startup"' & # '"$SCRIPT_NAME" >> /jffs/scripts/services-start
 				fi
 			else
 				echo "#!/bin/sh" > /jffs/scripts/services-start
 				echo "" >> /jffs/scripts/services-start
-				echo "/jffs/scripts/$SCRIPT_NAME_LOWER startup"' & # '"$SCRIPT_NAME$" >> /jffs/scripts/services-start
+				echo "/jffs/scripts/$SCRIPT_NAME_LOWER startup"' & # '"$SCRIPT_NAME" >> /jffs/scripts/services-start
 				chmod 0755 /jffs/scripts/services-start
 			fi
 		;;


### PR DESCRIPTION
Fixed a bug found when adding the "**startup**" calls to the "**services-start**" script.

This bug was introduced on 2022-Jan-05 with PR #22:  https://github.com/jackyaz/scMerlin/pull/22/commits/1b98ca368b2f68ad94a12f87c8936326591a730e

But the changes never made it to the **master** branch so they're found only in the "**2.4.1**" version from the **develop** branch. When @decoderman (AKA @thelonelycoder) forked the repository, it inherited the bug which eventually made it into his "**2.5.0**" master release.

Here's the post in the SNB Forums where the bug was reported:

https://www.snbforums.com/threads/amtm-4-4-the-asuswrt-merlin-terminal-menu-march-10-2024.79665/page-19#post-897406
