### PR TITLE
Fix text alignment for longer model names

### DIFF
--- a/scmerlin.sh
+++ b/scmerlin.sh
@@ -1058,7 +1058,7 @@ ScriptHeader(){
 	printf "${BOLD}##   \__ \| (__ | |  | ||  __/| |   | || || | | |   ##${CLEARFORMAT}\\n"
 	printf "${BOLD}##   |___/ \___||_|  |_| \___||_|   |_||_||_| |_|   ##${CLEARFORMAT}\\n"
 	printf "${BOLD}##                                                  ##${CLEARFORMAT}\\n"
-	printf "${BOLD}##               %s on %-11s              ##${CLEARFORMAT}\\n" "$SCRIPT_VERSION" "$ROUTER_MODEL"
+	printf "${BOLD}##               %s on %-16s         ##${CLEARFORMAT}\\n" "$SCRIPT_VERSION" "$ROUTER_MODEL"
 	printf "${BOLD}##                                                  ##${CLEARFORMAT}\\n"
 	printf "${BOLD}##       https://github.com/jackyaz/scMerlin        ##${CLEARFORMAT}\\n"
 	printf "${BOLD}##                                                  ##${CLEARFORMAT}\\n"


### PR DESCRIPTION
Fix spacing in title card for longer model names such as RT-AX86U_Pro

![image](https://github.com/jackyaz/scMerlin/assets/35944068/c3066b2d-45f4-468e-ba50-a84c6f829c26)
